### PR TITLE
Fixing English Typos

### DIFF
--- a/en/content/faq
+++ b/en/content/faq
@@ -5,14 +5,14 @@
      It's done in a few steps:
      <ul>
       <li>
-        send an email to one of &lt;mailing_list_name&gt;-request@nutyx.org (<i>nutyx-support-request@nutyx.org</i> for example) by specifying:
+        Send an email to one of &lt;mailing_list_name&gt;-request@nutyx.org (<i>nutyx-support-request@nutyx.org</i> for example) by specifying:
        <b><i>subscribe</i></b> as the subject.
       <li>
        You will receive a confirmation mail. Check your spam mail.
       <li>
        Simply answer this last email by choosing "Reply" on your favorite email software.
       <li>
-       After a few minutes you will receive an  email that confirms you are registered on the mailing-list
+       After a few minutes, you will receive an  email that confirms you are registered on the mailing-list
       </ul>
       <table>
        <caption><EM>Available Mailing Lists:</EM></caption>
@@ -39,7 +39,7 @@
    <h2>NuTyX is not a multi-lib</h2>
     <p>
      It takes much more time to build up a multilib distribution.
-     Normally all the libraries need to be compiled in 64 and 32 bits.
+     Normally all the libraries need to be compiled in both 64 and 32 bit.
     <p>
      Today, it's not possible to produce a multilib because there are links created at construction / installation of NuTyX (lib64->lib) under /lib and /usr.
 
@@ -64,7 +64,7 @@
       If you have a distribution (NuTyX or any other) with personal data and the system on the same partition,
       the installer will tell you during the installation process that there is already a distribution there but will not offer to format the partition.
       You will need to delete the <b>  /var, /proc, /sys, /usr, /sbin,</b> and <b>/etc </b> folders, but other folders such as <b>/home</b> and <b>/MP3</b> will not be touched.
-      So your data are safe. 
+      So your data is safe. 
     <li>
      Today it is very easy to configure a file server based on NFS, so that users could have their home folders on a remote server.
     <li>
@@ -127,7 +127,7 @@ logdir /var/log/pkgbuild</pre>
 
    <h2>How to activate the root account ?</h2>
     <p>
-     As default, NuTyX does not activate the root account but, if you wish to compile your own packages, it may be a good activate the root account.
+     As default, NuTyX does not activate the root account but, if you wish to compile your own packages, it may be a good idea to activate the root account.
      It's very simple, type:
      <pre class="command_user"><kbd>nu</kbd></pre>
      and choose <b>root</b> as user

--- a/en/content/news
+++ b/en/content/news
@@ -2,25 +2,25 @@
 
 <h2>NuTyX 11.1 available with cards 2.4.98</h2>
 <p>
- I'm very please to announce the new NuTyX 11.1 release.
+ I'm very pleased to announce the new NuTyX 11.1 release.
 <p>
- This new version contains more then 1000 packages upgrade.
+ This new version contains more than 1000 packages upgraded.
 <p>
- A 32 bits version of NuTyX 11.1 is now available as well.
+ A 32 bit version of NuTyX 11.1 is now available as well.
 <p>
  The base of NuTyX comes with the new kernel LTS 4.19.56 (4.9.183 for the 32 bits version) and the very new kernel 5.1.15 (in 64 bits only).
 <p>
- The gnu compiler is now the gcc 9.1.0.
+ The gnu compiler collection, gcc, is now gcc 9.1.0.
 <p>
- The graphical server is now in xorg-server 1.20.5, the mesa lib in 18.3.6, gtk3 3.24.9, qt 5.12.4.
+ The graphical server is now xorg-server 1.20.5, the mesa lib is 18.3.6, gtk3 is 3.24.9 and qt has been updated to 5.12.4.
 <p>
- The python 3.7.3 and 2.7.16 are updated as well
+ Python 3.7.3 and 2.7.16 have been included in this release.
 <p>
- The MATE Desktop Environment comes in 1.22.1 the very last version as well.
+ The MATE Desktop Environment comes in 1.22.1, the latest version.
 <p>
- The KDE Desktop plasma in 5.16.2, Framework in 5.59.0 and applications in 19.04.2
+ The KDE Plasma Desktop is now 5.16.2, the Framework is now 5.59.0 and applications are now 19.04.2
 <p>
- Browsers firefox in 67.0.4 and chromium in 74.0.3729.169 (build by the archlinux team and only in 64 bits)
+ The firefox browser has been updated to 67.0.4 and the chromium browser is updated to 74.0.3729.169 (build by the archlinux team and only in 64 bits)
 <p>
  Many desktop applications have been updated as well like thunderbird 60.7.2, Scribus 1.5.5, libreoffice 6.2.4.2, gimp 2.10.12, etc.
 <p>
@@ -31,9 +31,9 @@
    <p>
     The first ISO is a base NuTyX "rolling" version with a size of 384 Mbytes.
    <p>
-    A 5.3 GBytes ISO base NuTyX "fixed" version which contains a completed binaries repository of the 11.1 NuTyX.
-    You can install a complete NuTyX 11.1 without having to use internet.
-    To install packages from this ISO, onces your base system is installed, configured and booting,
+    A 5.3 GBytes ISO base NuTyX "fixed" version which contains a complete repository of the binaries for the NuTyX 11.1 release.
+    You can install NuTyX 11.1 completely without having to use internet.
+    To install packages from this ISO, once your base system is installed, configured and booting,
     it's just a question of mounting the media on the <b>/mnt</b> mounting point.
    <p>
     Suppose you media is found under <b>/dev/sdc1</b>, uses following command to mount it:
@@ -50,14 +50,14 @@
  ISOs are available on <a href="downloads">the download page.</a>
 <h2>CARDS</h2>
  <p>
-  CARDS is now able to track obsolets packages.
-  A package is obsolet when it's not available anymore on the remote server.
-  Such a package is delete automaticaly from your local installation if installed. 
+  CARDS is now able to track obsolete packages.
+  A package is obsolete when it's not available anymore on the remote server.
+  Such a package is deleted automatically from your local installation if installed. 
 <h2>Upgrade process</h2>
 <p>
  Since this is a minor release, an upgrade is possible.
 <p>
- For a successfull upgrade, the 'cards' package need to be update first.
+ For a successfull upgrade, the 'cards' package needs to be updated first.
 <p>
  Please use following commands to proceed:
  <pre class="command_user"><kbd>check</kbd></pre>
@@ -67,5 +67,5 @@
  <pre class="command_user"><kbd>sudo cards upgrade</kbd></pre>
 
 <h2>Old news</h2>
- Old news are now available <a href="old-news/?C=N;O=D">here</a>.
+ Old news is now available <a href="old-news/?C=N;O=D">here</a>.
 


### PR DESCRIPTION
Fixed typos present in both en/content/news and en/content/faq.